### PR TITLE
Fix NullTypeEnforcer simplifying dynamic null comparisons

### DIFF
--- a/src/reflaxe/compiler/NullTypeEnforcer.hx
+++ b/src/reflaxe/compiler/NullTypeEnforcer.hx
@@ -128,11 +128,11 @@ class NullTypeEnforcer {
 				if(e1.isNullExpr() && e2.isNullExpr()) {
 					expr.expr = TConst(TBool(true));
 				} else if(e1.isNullExpr()) {
-					if(!e2.t.isNull()) {
+					if(!e2.t.isNull() && !e2.t.isDynamic()) {
 						expr.expr = TConst(TBool(false));
 					}
 				} else if(e2.isNullExpr()) {
-					if(!e1.t.isNull()) {
+					if(!e1.t.isNull() && !e1.t.isDynamic()) {
 						expr.expr = TConst(TBool(false));
 					}
 				}
@@ -141,11 +141,11 @@ class NullTypeEnforcer {
 				if(e1.isNullExpr() && e2.isNullExpr()) {
 					expr.expr = TConst(TBool(false));
 				} else if(e1.isNullExpr()) {
-					if(!e2.t.isNull()) {
+					if(!e2.t.isNull() && !e2.t.isDynamic()) {
 						expr.expr = TConst(TBool(true));
 					}
 				} else if(e2.isNullExpr()) {
-					if(!e1.t.isNull()) {
+					if(!e1.t.isNull() && !e1.t.isDynamic()) {
 						expr.expr = TConst(TBool(true));
 					}
 				}


### PR DESCRIPTION
Because null is a valid value for Dynamic, even in strict null safety mode.