### PR TITLE
Fix repeat var fixer

### DIFF
--- a/src/reflaxe/compiler/RepeatVariableFixer.hx
+++ b/src/reflaxe/compiler/RepeatVariableFixer.hx
@@ -112,23 +112,20 @@ class RepeatVariableFixer {
 	}
 
 	function handleExpression(expr: TypedExpr): TypedExpr {
-		function mapSubExprs(subExpr: TypedExpr) {
-			switch(subExpr.expr) {
-				case TBlock(_): {
-					return handleBlock(subExpr);
-				}
-				case TLocal(tvar): {
-					final replacement = varReplacement(tvar.id);
-					if(replacement != null) {
-						return subExpr.copy(TLocal(replacement));
-					}
-				}
-				case _:
+		switch(expr.expr) {
+			case TBlock(_): {
+				return handleBlock(expr);
 			}
-			return haxe.macro.TypedExprTools.map(subExpr, mapSubExprs);
+			case TLocal(tvar): {
+				final replacement = varReplacement(tvar.id);
+				if(replacement != null) {
+					return expr.copy(TLocal(replacement));
+				}
+			}
+			case _:
 		}
 
-		return haxe.macro.TypedExprTools.map(expr, mapSubExprs);
+		return haxe.macro.TypedExprTools.map(expr, handleExpression);
 	}
 
 	function handleBlock(subExpr: TypedExpr): TypedExpr {


### PR DESCRIPTION
It took me waaaaaaaaaaaaaaaaaaay too long to figure out why this was happening...

Fixes the following issue:
```haxe
var a = "asdf";
var b = a;
var a = 1234;
var b = a;
Sys.println(b);
```
output:
```dart
String a = 'asdf';
String b = a;
int a2 = 1234;
int b2 = a; // <-- should be a2
print(b2);
```

`handleExpression` was skipping the evaluation of the first expression.