### PR TITLE
Make variables pass through expression preprocessors first

### DIFF
--- a/src/reflaxe/BaseCompiler.hx
+++ b/src/reflaxe/BaseCompiler.hx
@@ -257,6 +257,23 @@ class BaseCompilerOptions {
 		paramTypes: Null<Array<MetaArgumentType>>,
 		compileFunc: Null<(MetadataEntry, Array<String>) -> Null<String>>
 	}> = [];
+
+	/**
+		Converts all static variable declarations to have a self
+		calling lambda function where needed. This does not affect
+		variables with a deterministic/constant value.
+
+		Useful if your target language does not support blocks as values
+		for variables, however the target language also needs to support
+		lambda function declarations and executing code directly on the top stack
+		(great examples are lua and python).
+
+		You can use the ClassVarData.canBeInlined variable to check if
+		the variable does not need any kind of wrapper. You can also use
+		it with `convertStaticVarExpressionsToFunctions` turned off to
+		implement your own system.
+	**/
+	public var convertStaticVarExpressionsToFunctions: Bool = true;
 }
 
 /**

--- a/src/reflaxe/ReflectCompiler.hx
+++ b/src/reflaxe/ReflectCompiler.hx
@@ -623,6 +623,9 @@ class ReflectCompiler {
 			preprocessor.process(dataProxy, compiler);
 		}
 
+		if (dataProxy.expr == null)
+			return data;
+
 		// The EverythingIsAnExpression sanitizer (tm) should convert a TBinop(op, e1, TBlock(<...>)) into just a block,
 		// we can use this to our advantage to check if we can directly inline the value,
 		// otherwise we may need to wrap the code inside a function and then call it immediately to get the final value.

--- a/src/reflaxe/ReflectCompiler.hx
+++ b/src/reflaxe/ReflectCompiler.hx
@@ -640,7 +640,7 @@ class ReflectCompiler {
 			}
 		}
 
-		var isInline = e.expr.match(TBinop(_, _, _)); //e.isMutator();
+		var isInline = e.expr.match(TBinop(_, _, _));
 		var finalExpr = switch(e.expr)
 		{
 			case TBinop(op, e1, e2):
@@ -664,91 +664,6 @@ class ReflectCompiler {
 
 		return data;
 	}
-
-	/*
-	static function preprocessVar(compiler: BaseCompiler, field: ClassField, data: ClassVarData): ClassVarData {
-		var defaultExpr = field.expr();
-		if(defaultExpr == null) {
-			return data;
-		}
-
-		var classRef:Ref<ClassType> = {
-			get: () -> data.classType,
-			toString: () -> data.classType.name
-		};
-		var fieldRef:Ref<ClassField> = {
-			get: () -> field,
-			toString: () -> field.name
-		};
-
-		var fieldExpr:TypedExpr = {
-			expr: TField({
-				expr: TTypeExpr(TClassDecl(classRef)),
-				pos: defaultExpr.pos,
-				t: defaultExpr.t
-			}, FStatic(classRef, fieldRef)),
-			pos: defaultExpr.pos,
-			t: defaultExpr.t
-		};
-
-		defaultExpr = {
-			expr: TBinop(OpAssign, fieldExpr, defaultExpr),
-			pos: defaultExpr.pos,
-			t: defaultExpr.t
-		};
-
-		if(compiler.options.enforceNullTyping) {
-			NullTypeEnforcer.modifyExpression(defaultExpr);
-		}
-		final dataProxy = new ClassFuncData(data.classType.moduleId(), data.classType, field, data.isStatic, MethNormal, field.type, [], null, defaultExpr);
-		for(preprocessor in compiler.expressionPreprocessors) {
-			preprocessor.process(dataProxy, compiler);
-		}
-
-		if (dataProxy.expr == null)
-			return data;
-
-		// The EverythingIsAnExpression sanitizer (tm) should convert a TBinop(op, e1, TBlock(<...>)) into just a block,
-		// we can use this to our advantage to check if we can directly inline the value,
-		// otherwise we may need to wrap the code inside a function and then call it immediately to get the final value.
-		var inlineExpr:Null<TypedExpr> = switch(dataProxy.expr.expr)
-		{
-			case TBinop(op, e1, e2):
-				if (op.match(OpAssign) || op.match(OpAssignOp(_)))
-				{
-					switch(e1.expr)
-					{
-						case TField(targetExpr, fieldAccess):
-							if (targetExpr.expr.match(TTypeExpr(TClassDecl(_))))
-							{
-								switch(targetExpr.expr)
-								{
-									case TTypeExpr(TClassDecl(d)):
-										if (d == classRef)
-											e2;
-										else
-											null;
-									case _:
-										null;
-								}
-							}
-							else
-								null;
-						case _:
-							null;
-					}
-				}
-				else
-					null;
-			case _:
-				null;
-		}
-		if (inlineExpr != null)
-			Reflect.setField(dataProxy, "expr", inlineExpr);
-			
-		Reflect.setField(field, "expr", () -> dataProxy.expr);
-		return data;
-	}*/
 
 	// =======================================================
 	// * transpileEnum

--- a/src/reflaxe/ReflectCompiler.hx
+++ b/src/reflaxe/ReflectCompiler.hx
@@ -592,10 +592,44 @@ class ReflectCompiler {
 		}
 
 		final fE = field.buildTField(data.classType);
-		var e = if (compiler.options.convertStaticVarExpressionsToFunctions) {
-			data.expr.transformLambaSelfCall(true);
-		} else {
-			data.expr.transformAssign(fE);
+		var e = {
+			var canInline:TypedExpr -> Bool;
+			canInline = (ex:TypedExpr) -> switch(ex.expr)
+			{
+				case TConst(_) |
+					 TLocal(_) |
+					 TArray(_, _) |
+					 TField(_, _) |
+					 TTypeExpr(_) |
+					 TObjectDecl(_) |
+					 TArrayDecl(_) |
+					 TCall(_, _) |
+					 TNew(_, _, _) |
+					 TFunction(_) |
+					 TCast(_, _) |
+					 TMeta(_, _) |
+					 TEnumParameter(_, _, _) |
+					 TEnumIndex(_) |
+					 TIdent(_): true;
+
+				case TThrow(_): true;
+				case TUnop(_, _, _): false;
+				case TParenthesis(e): canInline(e);
+				case TBinop(op, e1, e2):
+					if (!op.match(OpAssign) && !op.match(OpAssignOp(_)))
+						canInline(e2);
+					else 
+						false;
+				case _: false;
+			}
+
+			if (canInline(data.expr)) {
+				data.expr.transformAssign(fE);
+			} else if (compiler.options.convertStaticVarExpressionsToFunctions) {
+				data.expr.transformLambaSelfCall(true);
+			} else {
+				data.expr.transformAssign(fE);
+			}
 		};
 
 		data.setExpr(e);

--- a/src/reflaxe/ReflectCompiler.hx
+++ b/src/reflaxe/ReflectCompiler.hx
@@ -592,7 +592,11 @@ class ReflectCompiler {
 		}
 
 		final fE = field.buildTField(data.classType);
-		var e = data.expr.transformAssign(fE);
+		var e = if (compiler.options.convertStaticVarExpressionsToFunctions) {
+			data.expr.transformLambaSelfCall(true);
+		} else {
+			data.expr.transformAssign(fE);
+		};
 
 		data.setExpr(e);
 
@@ -625,7 +629,7 @@ class ReflectCompiler {
 		}
 
 		data.setExpr(finalExpr);
-		data.setCanBeInlined(isInline);
+		data.setCanBeInlined(compiler.options.convertStaticVarExpressionsToFunctions ? true : isInline);
 
 		return data;
 	}

--- a/src/reflaxe/ReflectCompiler.hx
+++ b/src/reflaxe/ReflectCompiler.hx
@@ -36,6 +36,7 @@ using reflaxe.helpers.NameMetaHelper;
 using reflaxe.helpers.NullableMetaAccessHelper;
 using reflaxe.helpers.TypeHelper;
 using reflaxe.helpers.TypedExprHelper;
+using reflaxe.helpers.NullHelper;
 
 /**
 	The heart of Reflaxe.
@@ -592,7 +593,7 @@ class ReflectCompiler {
 		}
 
 		final fE = field.buildTField(data.classType);
-		var e = if (compiler.options.convertStaticVarExpressionsToFunctions) {
+		var e:TypedExpr = if (compiler.options.convertStaticVarExpressionsToFunctions) {
 			data.expr.transformLambaSelfCall(true);
 		} else {
 			data.expr.transformAssign(fE);
@@ -622,7 +623,7 @@ class ReflectCompiler {
 									switch(b.expr)
 									{
 										case TReturn(e):
-											e;
+											e.trustMe();
 										case _:
 											b;
 									}
@@ -633,10 +634,10 @@ class ReflectCompiler {
 							case _: data.expr;
 						}
 					
-					case _: data.expr;
+					case _: data.expr.trustMe();
 				}
 			} else {
-				data.expr;
+				data.expr.trustMe();
 			}
 		}
 

--- a/src/reflaxe/data/ClassFieldData.hx
+++ b/src/reflaxe/data/ClassFieldData.hx
@@ -1,0 +1,112 @@
+package reflaxe.data;
+
+#if (macro || reflaxe_runtime)
+
+import reflaxe.preprocessors.ExpressionPreprocessor;
+import haxe.macro.Type;
+
+using reflaxe.helpers.ClassFieldHelper;
+using reflaxe.helpers.NameMetaHelper;
+using reflaxe.helpers.NullableMetaAccessHelper;
+using reflaxe.helpers.NullHelper;
+using reflaxe.helpers.PositionHelper;
+using reflaxe.helpers.TypedExprHelper;
+
+class ClassFieldData {
+	public final id: String;
+	
+	public final classType: ClassType;
+	public final field: ClassField;
+
+	public final isStatic: Bool;
+
+	public var expr(default, null): Null<TypedExpr>;
+
+	var variableUsageCount: Null<Map<Int, Int>>; // Not quite sure if its necessary here, but keep it :P
+
+	public function new(id:String, classType: ClassType, field: ClassField, isStatic: Bool, expr:Null<TypedExpr> = null) {
+		this.id = id;
+
+		this.classType = classType;
+		this.field = field;
+
+		this.isStatic = isStatic;
+
+		this.expr = expr;
+	}
+
+	/**
+		Sets the typed expression.
+		Invalidates any cached information regarding the old expression.
+	**/
+	public function setExpr(e: TypedExpr) {
+		expr = e;
+
+		// The expression changed, so the stored usage count data is now invalid.
+		variableUsageCount = null;
+	}
+
+	/**
+		Works the same as `setExpr`, but takes an array of expressions.
+
+		If just one expression, it is used directly.
+		Multiple are converted into a block expression.
+	**/
+	public function setExprList(expressions: Array<TypedExpr>) {
+		if(expressions.length == 1) {
+			setExpr(expressions[0].trustMe());
+		} else if(expr != null) {
+			// Retain the previous expression's Position and Type.
+			setExpr(expr.copy(TBlock(expressions)));
+		} else {
+			throw "`expr` must not be `null` when using ClassFuncData.setExprList.";
+		}
+	}
+
+	/**
+		A map of the number of times a variable is used can optionally
+		be provided for later reference.
+
+		This is usually calculated using `EverythingIsExprSanitizer` prior
+		to other optimizations. 
+	**/
+	public function setVariableUsageCount(usageMap: Map<Int, Int>) {
+		variableUsageCount = usageMap;
+	}
+
+	/**
+		Returns the variable usage count.
+		If it has not been calculated yet, it is calculated here.
+	**/
+	public function getOrFindVariableUsageCount(): Map<Int, Int> {
+		if(expr == null) {
+			return [];
+		}
+
+		final map: Map<Int, Int> = [];
+		function count(e: TypedExpr) {
+			switch(e.expr) {
+				case TVar(tvar, _): {
+					map.set(tvar.id, 0);
+				}
+				case TLocal(tvar): {
+					map.set(tvar.id, (map.get(tvar.id) ?? 0) + 1);
+				}
+				case _:
+			}
+			return haxe.macro.TypedExprTools.map(e, count);
+		}
+		count(expr);
+		return variableUsageCount = map;
+	}
+
+	/**
+		Applies preprocessors to the `expr`.
+	**/
+	public function applyPreprocessors(compiler: BaseCompiler, preprocessors: Array<ExpressionPreprocessor>) {
+		for(processor in preprocessors) {
+			processor.process(this, compiler);
+		}
+	}
+}
+#end

--- a/src/reflaxe/data/ClassFuncData.hx
+++ b/src/reflaxe/data/ClassFuncData.hx
@@ -15,13 +15,7 @@ using reflaxe.helpers.NullHelper;
 using reflaxe.helpers.PositionHelper;
 using reflaxe.helpers.TypedExprHelper;
 
-class ClassFuncData {
-	public final id: String;
-
-	public final classType: ClassType;
-	public final field: ClassField;
-
-	public final isStatic: Bool;
+class ClassFuncData extends ClassFieldData {
 	public final kind: MethodKind;
 
 	public final ret: Type;
@@ -30,10 +24,6 @@ class ClassFuncData {
 
 	public final property: Null<ClassField>;
 
-	public var expr(default, null): Null<TypedExpr>;
-
-	var variableUsageCount: Null<Map<Int, Int>>; // Access using `getOrFindVariableUsageCount`
-
 	public function new(
 		id: String,
 		classType: ClassType, field: ClassField, isStatic: Bool, kind: MethodKind, ret: Type,
@@ -41,18 +31,12 @@ class ClassFuncData {
 		extractArgumentMetadata: Bool = true,
 		property: Null<ClassField> = null
 	) {
-		this.id = id;
-
-		this.classType = classType;
-		this.field = field;
-
-		this.isStatic = isStatic;
+		super(id, classType, field, isStatic, expr);
 		this.kind = kind;
 
 		this.ret = ret;
 		this.args = args;
 		this.tfunc = tfunc;
-		this.expr = expr;
 
 		if(extractArgumentMetadata) {
 			extractArgumentMeta();
@@ -68,15 +52,6 @@ class ClassFuncData {
 	**/
 	public function clone(): ClassFuncData {
 		return new ClassFuncData(id, classType, field, isStatic, kind, ret, args, tfunc, expr, false, property);
-	}
-
-	/**
-		Applies preprocessors to the `expr`.
-	**/
-	public function applyPreprocessors(compiler: BaseCompiler, preprocessors: Array<ExpressionPreprocessor>) {
-		for(processor in preprocessors) {
-			processor.process(this, compiler);
-		}
 	}
 
 	/**
@@ -157,71 +132,6 @@ class ClassFuncData {
 
 	public function isSetter() {
 		return isSetterName() && property != null;
-	}
-
-	/**
-		Sets the typed expression.
-		Invalidates any cached information regarding the old expression.
-	**/
-	public function setExpr(e: TypedExpr) {
-		expr = e;
-
-		// The expression changed, so the stored usage count data is now invalid.
-		variableUsageCount = null;
-	}
-
-	/**
-		Works the same as `setExpr`, but takes an array of expressions.
-
-		If just one expression, it is used directly.
-		Multiple are converted into a block expression.
-	**/
-	public function setExprList(expressions: Array<TypedExpr>) {
-		if(expressions.length == 1) {
-			setExpr(expressions[0].trustMe());
-		} else if(expr != null) {
-			// Retain the previous expression's Position and Type.
-			setExpr(expr.copy(TBlock(expressions)));
-		} else {
-			throw "`expr` must not be `null` when using ClassFuncData.setExprList.";
-		}
-	}
-
-	/**
-		Returns the variable usage count.
-		If it has not been calculated yet, it is calculated here.
-	**/
-	public function getOrFindVariableUsageCount(): Map<Int, Int> {
-		if(expr == null) {
-			return [];
-		}
-
-		final map: Map<Int, Int> = [];
-		function count(e: TypedExpr) {
-			switch(e.expr) {
-				case TVar(tvar, _): {
-					map.set(tvar.id, 0);
-				}
-				case TLocal(tvar): {
-					map.set(tvar.id, (map.get(tvar.id) ?? 0) + 1);
-				}
-				case _:
-			}
-			return haxe.macro.TypedExprTools.map(e, count);
-		}
-		count(expr);
-		return variableUsageCount = map;
-	}
-
-	/**
-		A map of the number of times a variable is used can optionally
-		be provided for later reference.
-
-		This is usually calculated using `EverythingIsExprSanitizer` prior
-		to other optimizations. 
-	**/
-	public function setVariableUsageCount(usageMap: Map<Int, Int>) {
-		variableUsageCount = usageMap;
 	}
 
 	/**

--- a/src/reflaxe/data/ClassVarData.hx
+++ b/src/reflaxe/data/ClassVarData.hx
@@ -16,6 +16,8 @@ class ClassVarData extends ClassFieldData {
 	public final read: VarAccess;
 	public final write: VarAccess;
 
+	public var canBeInlined(default, null): Bool = false;
+
 	public var getter(default, null): Null<ClassField>;
 	public var setter(default, null): Null<ClassField>;
 
@@ -77,6 +79,10 @@ class ClassVarData extends ClassFieldData {
 			}
 		}
 		return null;
+	}
+
+	public function setCanBeInlined(value: Bool) {
+		canBeInlined = value;
 	}
 }
 

--- a/src/reflaxe/data/ClassVarData.hx
+++ b/src/reflaxe/data/ClassVarData.hx
@@ -12,22 +12,16 @@ using reflaxe.helpers.NullableMetaAccessHelper;
 using reflaxe.helpers.PositionHelper;
 using reflaxe.helpers.TypedExprHelper;
 
-class ClassVarData {
-	public var classType(default, null): ClassType;
-	public var field(default, null): ClassField;
-
-	public var isStatic(default, null): Bool;
-	public var read(default, null): VarAccess;
-	public var write(default, null): VarAccess;
+class ClassVarData extends ClassFieldData {
+	public final read: VarAccess;
+	public final write: VarAccess;
 
 	public var getter(default, null): Null<ClassField>;
 	public var setter(default, null): Null<ClassField>;
 
-	public function new(classType: ClassType, field: ClassField, isStatic: Bool, read: VarAccess, write: VarAccess) {
-		this.classType = classType;
-		this.field = field;
+	public function new(id:String, classType: ClassType, field: ClassField, isStatic: Bool, read: VarAccess, write: VarAccess, expr:Null<TypedExpr> = null) {
+		super(id, classType, field, isStatic, expr);
 
-		this.isStatic = isStatic;
 		this.read = read;
 		this.write = write;
 

--- a/src/reflaxe/helpers/ClassFieldHelper.hx
+++ b/src/reflaxe/helpers/ClassFieldHelper.hx
@@ -15,6 +15,8 @@ import reflaxe.data.ClassFieldData;
 
 using reflaxe.helpers.NameMetaHelper;
 using reflaxe.helpers.NullableMetaAccessHelper;
+using reflaxe.helpers.RefHelper;
+using reflaxe.helpers.ClassTypeHelper;
 
 /**
 	Quick static extensions to help with `ClassField`.
@@ -184,6 +186,26 @@ class ClassFieldHelper {
 		} else {
 			field.name;
 		}
+	}
+
+	public static function buildTField(field: ClassField, clsType: ClassType, isStatic: Null<Bool> = null):TypedExpr {
+		if(isStatic == null) {
+			isStatic = false;
+			for(s in clsType.statics.get()) {
+				if(equals(s, field)) {
+					isStatic = true;
+					break;
+				}
+			}
+		}
+		var fa = if (isStatic) {
+			FStatic(clsType.buildRef(), field.buildRef());
+		} else {
+			FInstance(clsType.buildRef(), clsType.params.map(p -> p.t), field.buildRef());
+		}
+
+		final clsRef = clsType.buildRef();
+		return TypedExprHelper.make(TField(clsType.generateDeclTExpr(TInst(clsRef, clsType.params.map(p -> p.t)), field.pos), fa), field.type, field.pos);
 	}
 }
 

--- a/src/reflaxe/helpers/ClassFieldHelper.hx
+++ b/src/reflaxe/helpers/ClassFieldHelper.hx
@@ -11,6 +11,7 @@ import haxe.macro.Type;
 import reflaxe.data.ClassFuncArg;
 import reflaxe.data.ClassFuncData;
 import reflaxe.data.ClassVarData;
+import reflaxe.data.ClassFieldData;
 
 using reflaxe.helpers.NameMetaHelper;
 using reflaxe.helpers.NullableMetaAccessHelper;
@@ -77,7 +78,8 @@ class ClassFieldHelper {
 
 		return switch(field.kind) {
 			case FVar(read, write): {
-				final result = new ClassVarData(clsType, field, isStatic, read, write);
+				var e = field.expr();
+				final result = new ClassVarData(id, clsType, field, isStatic, read, write, e);
 				findVarData_cache.set(id, result);
 				result;
 			}
@@ -160,7 +162,7 @@ class ClassFieldHelper {
 		}
 	}
 
-	public static function getAllVariableNames(data: ClassFuncData, compiler: BaseCompiler) {
+	public static function getAllVariableNames(data: ClassFieldData, compiler: BaseCompiler) {
 		final fields = data.classType.fields.get();
 		final fieldNames = [];
 		for(f in fields) {

--- a/src/reflaxe/helpers/ClassTypeHelper.hx
+++ b/src/reflaxe/helpers/ClassTypeHelper.hx
@@ -4,9 +4,11 @@ package reflaxe.helpers;
 
 import haxe.macro.Expr;
 import haxe.macro.Type;
+import reflaxe.helpers.TypedExprHelper;
 
 using reflaxe.helpers.ClassFieldHelper;
 using reflaxe.helpers.NullHelper;
+using reflaxe.helpers.RefHelper;
 
 /**
 	Helper functions for `ClassType`.
@@ -130,6 +132,10 @@ class ClassTypeHelper {
 				t: constructorExpr.t
 			}
 		}
+	}
+
+	public static function generateDeclTExpr(cls: ClassType, t:Type, pos:Null<Position>): TypedExpr {
+		return TypedExprHelper.make(TTypeExpr(TClassDecl(cls.buildRef())), t, pos);
 	}
 }
 

--- a/src/reflaxe/helpers/RefHelper.hx
+++ b/src/reflaxe/helpers/RefHelper.hx
@@ -1,0 +1,20 @@
+package reflaxe.helpers;
+
+import haxe.macro.Type.Ref;
+#if (macro || reflaxe_runtime)
+
+class RefHelper {
+	public static function buildRef<T>(c:T):Ref<T> {
+		return {
+			get: () -> c,
+			toString: () -> Std.string(c)
+		}
+	}
+
+	public static function replaceRef<T>(ref:Ref<T>, newValue:T):Ref<T> {
+		Reflect.setField(ref, "get", () -> newValue);
+		return ref;
+	}
+}
+
+#end

--- a/src/reflaxe/helpers/RefHelper.hx
+++ b/src/reflaxe/helpers/RefHelper.hx
@@ -1,7 +1,8 @@
 package reflaxe.helpers;
 
-import haxe.macro.Type.Ref;
 #if (macro || reflaxe_runtime)
+
+import haxe.macro.Type.Ref;
 
 class RefHelper {
 	public static function buildRef<T>(c:T):Ref<T> {

--- a/src/reflaxe/helpers/TypedExprHelper.hx
+++ b/src/reflaxe/helpers/TypedExprHelper.hx
@@ -110,6 +110,10 @@ class TypedExprHelper {
 		}
 	}
 
+	public static function transformAssign(expr: TypedExpr, target: TypedExpr): TypedExpr {
+		return make(TBinop(OpAssign, target, expr), expr.t, expr.pos);
+	}
+
 	public static function hasMeta(expr: TypedExpr, name: String): Bool {
 		return switch(expr.expr) {
 			case TParenthesis(e): {

--- a/src/reflaxe/helpers/TypedExprHelper.hx
+++ b/src/reflaxe/helpers/TypedExprHelper.hx
@@ -110,8 +110,27 @@ class TypedExprHelper {
 		}
 	}
 
+	/**
+		Transforms the typed expression into an assignment expression given a `target` typedExpr.
+		This will return (in Haxe code) `target = self`.
+	**/
 	public static function transformAssign(expr: TypedExpr, target: TypedExpr): TypedExpr {
 		return make(TBinop(OpAssign, target, expr), expr.t, expr.pos);
+	}
+
+	/**
+		Transforms the typed expression into a lamba function that auto calls itself immediately after.
+	**/
+	public static function transformLambaSelfCall(expr: TypedExpr, addReturn: Bool = false): TypedExpr {
+		final mk = (e:TypedExprDef) -> make(e, expr.t, expr.pos);
+		return mk(TCall(mk(TParenthesis(mk(TFunction({
+			args: [],
+			t: expr.t,
+			expr: if (addReturn)
+					mk(TReturn(mk(expr.expr)))
+				else 
+					expr
+		})))), []));
 	}
 
 	public static function hasMeta(expr: TypedExpr, name: String): Bool {

--- a/src/reflaxe/preprocessors/BasePreprocessor.hx
+++ b/src/reflaxe/preprocessors/BasePreprocessor.hx
@@ -1,7 +1,7 @@
 package reflaxe.preprocessors;
 
-import reflaxe.data.ClassFuncData;
+import reflaxe.data.ClassFieldData;
 
 abstract class BasePreprocessor {
-	public abstract function process(data: ClassFuncData, compiler: BaseCompiler): Void;
+	public abstract function process(data: ClassFieldData, compiler: BaseCompiler): Void;
 }

--- a/src/reflaxe/preprocessors/ExpressionPreprocessor.hx
+++ b/src/reflaxe/preprocessors/ExpressionPreprocessor.hx
@@ -1,5 +1,7 @@
 package reflaxe.preprocessors;
 
+import reflaxe.data.ClassFuncArg;
+import reflaxe.data.ClassFieldData;
 import reflaxe.compiler.NullTypeEnforcer;
 import reflaxe.data.ClassFuncData;
 import reflaxe.preprocessors.BasePreprocessor;
@@ -162,7 +164,7 @@ class ExpressionPreprocessorHelper {
 	/**
 		This is where the implementations for the builtin `ExpressionPreprocessor` are.
 	**/
-	public static function process(self: ExpressionPreprocessor, data: ClassFuncData, compiler: BaseCompiler) {
+	public static function process(self: ExpressionPreprocessor, data: ClassFieldData, compiler: BaseCompiler) {
 		if(data.expr == null) {
 			return;
 		}
@@ -182,12 +184,13 @@ class ExpressionPreprocessorHelper {
 				preventRepeatArguments: preventRepeatArguments,
 				extraReservedNames: extraReservedNames
 			}): {
+				var args:Array<ClassFuncArg> = (data is ClassFuncData) ? cast(data, ClassFuncData).args : [];
 				final reservedNames = data.getAllVariableNames(compiler).concatIfNotNull(extraReservedNames);
-				final rvf = new PreventRepeatVariablesImpl(data.expr, null, data.args.map(a -> a.originalName).concat(reservedNames));
+				final rvf = new PreventRepeatVariablesImpl(data.expr, null, args.map(a -> a.originalName).concat(reservedNames));
 
 				// Ensure the argument names don't match any class variables.
-				if(preventRepeatArguments) {
-					for(arg in data.args) {
+				if(preventRepeatArguments && data is ClassFuncData) {
+					for(arg in (cast(data, ClassFuncData)).args) {
 						if(arg.ensureNameDoesntMatch(reservedNames) && arg.tvar != null) {
 							rvf.registerVarReplacement(arg.getName(), arg.tvar);
 						}


### PR DESCRIPTION
Read #45 for more information.

In short, static variables do not have their default expression passed through preprocessors like functions do, causing unintended behavior in certain classes.

The fix was basically just create a "virtual" ClassFuncData object and then pass that to the preprocessors, extract the final modified expr, do some final processing and overwrite the expr() function in the ClassVarData to return our fixed expression.

Fixes #45, I opened it 11 hours ago and I never expected to be able to fix this issue any time soon, guess I out-did myself, whoops...