### PR TITLE
Prevent vshaxe and -D no-compilation from making an output

### DIFF
--- a/src/reflaxe/ReflectCompiler.hx
+++ b/src/reflaxe/ReflectCompiler.hx
@@ -55,7 +55,11 @@ class ReflectCompiler {
 		#elseif eval
 		static var called = false;
 		if(!called) {
-			if(#if eval !Context.defined("display") #else true #end) {
+			if(#if eval
+				!Context.defined("display") &&
+				!Context.defined("no-compilation") &&
+				!Compiler.getConfiguration().args.contains("--no-output")
+			#else true #end) {
 				Context.onAfterTyping(onAfterTyping);
 				Context.onAfterGenerate(onAfterGenerate);
 				checkServerCache();


### PR DESCRIPTION
reflaxe will compile an output even if -D no-compilation is defined. This PR fixes that and also prevents IDE extensions like vshaxe from making reflaxe compile an output on startup, which can get super anoying.

(My bad for creating this secondary PR, i accidentally messed up the setup for the first one, whoops)