### PR TITLE
Rename variable `isPure` to `hasEffect`

### DIFF
--- a/src/reflaxe/preprocessors/implementations/RemovePureExpressionsImpl.hx
+++ b/src/reflaxe/preprocessors/implementations/RemovePureExpressionsImpl.hx
@@ -209,13 +209,13 @@ private class OptimizerTexpr {
 				TSwitch(_), TArrayDecl(_), TBlock(_),
 				TObjectDecl(_), TVar(_):
 			{
-				var isPure = true;
+				var hasEffect = false;
 				TypedExprTools.iter(expr, function(subExpr) {
 					if(hasSideEffects(subExpr)) {
-						isPure = false;
+						hasEffect = true;
 					}
 				});
-				return isPure;
+				return hasEffect;
 			}
 			case _: {
 				return false;


### PR DESCRIPTION
We already have a function called isPure so that variable was shadowing it, causing a bunch of issues. How did i not notice this??