### PR TITLE
Fix issue with Context.onAfterTyping()

### DIFF
--- a/src/reflaxe/ReflectCompiler.hx
+++ b/src/reflaxe/ReflectCompiler.hx
@@ -168,7 +168,13 @@ class ReflectCompiler {
 	static var haxeProvidedModuleTypes: Null<Array<ModuleType>>;
 
 	static function onAfterTyping(moduleTypes: Array<ModuleType>) {
-		haxeProvidedModuleTypes = moduleTypes;
+		if(haxeProvidedModuleTypes == null){
+			haxeProvidedModuleTypes = moduleTypes;
+		} else {
+			for(type in moduleTypes){
+				haxeProvidedModuleTypes.push(type);
+			}
+		}
 	}
 
 	static function onAfterGenerate() {


### PR DESCRIPTION
I found an issue where all types would get discarded if a new type was defined in a `Context.onAfterTyping` callback.

This PR seems to fix it on my end but let me know if theres anything wrong with it.